### PR TITLE
Add E2B cloud execution adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,22 @@
 {
-  "name": "qckfx-agent",
-  "version": "0.1.0",
+  "name": "qckfx",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "qckfx-agent",
-      "version": "0.1.0",
+      "name": "qckfx",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@e2b/code-interpreter": "^1.0.4",
         "commander": "^13.1.0",
         "dotenv": "^16.4.5",
         "glob": "^8.1.0"
+      },
+      "bin": {
+        "qckfx": "dist/cli.js"
       },
       "devDependencies": {
         "@types/glob": "^8.1.0",
@@ -571,6 +575,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.4.tgz",
+      "integrity": "sha512-P9xQgtMh71TA7tHTnbDe68zcI+TPnkyyfBIhGaUr4iUEIXN7yI01DyjmmdEwXTk5OlISBJYkoxCVj2dwmHqIkA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
+      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.3.tgz",
+      "integrity": "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "2.0.0-rc.3"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -593,6 +622,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@e2b/code-interpreter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@e2b/code-interpreter/-/code-interpreter-1.0.4.tgz",
+      "integrity": "sha512-8y82UMXBdf/hye8bX2Fn04JlL72rvOenVgsvMZ+cAJqo6Ijdl4EmzzuFpM4mz9s+EJ29+34lGHBp277tiLWuiA==",
+      "license": "MIT",
+      "dependencies": {
+        "e2b": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2329,6 +2370,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2513,6 +2560,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/e2b": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/e2b/-/e2b-1.0.7.tgz",
+      "integrity": "sha512-7msagBbQ8tm51qaGp+hdaaaMjGG3zCzZtUS8bnz+LK7wdwtVTA1PmX+1Br9E3R7v6XIchnNWRpei+VjvGcfidA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.2.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-web": "2.0.0-rc.3",
+        "compare-versions": "^6.1.0",
+        "openapi-fetch": "^0.9.7",
+        "platform": "^1.3.6"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4778,6 +4842,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.9.8.tgz",
+      "integrity": "sha512-zM6elH0EZStD/gSiNlcPrzXcVQ/pZo3BDvC6CDwRDUt1dDzxlshpmQnpD6cZaJ39THaSmwVCxxRrPKNM1hHrDg==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.8"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.8.tgz",
+      "integrity": "sha512-1eNjQtbfNi5Z/kFhagDIaIRj6qqDzhjNJKz8cmMW0CVdGwT6e1GLbAfgI0d28VTJa1A8jz82jm/4dG8qNoNS8g==",
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5039,6 +5118,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@e2b/code-interpreter": "^1.0.4",
     "commander": "^13.1.0",
     "dotenv": "^16.4.5",
     "glob": "^8.1.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ dotenv.config();
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 
 // Chat command functionality, extracted to be reused in default command
-const startChat = async (options: any) => {
+const startChat = async (options: { debug?: boolean, model?: string, e2bSandboxId?: string }) => {
   if (!ANTHROPIC_API_KEY) {
     console.error('Error: ANTHROPIC_API_KEY environment variable is required');
     process.exit(1);
@@ -37,6 +37,7 @@ const startChat = async (options: any) => {
   // Create the agent
   const agent = createAgent({
     modelProvider,
+    environment: { type: options.e2bSandboxId ? 'e2b' : 'local', sandboxId: options.e2bSandboxId || '' },
     logger: createLogger({ 
       level: options.debug ? LogLevel.DEBUG : LogLevel.INFO 
     }),
@@ -83,6 +84,7 @@ const startChat = async (options: any) => {
       console.log('\nParameters:');
       console.log('  -d, --debug       Enable debug logging');
       console.log('  -m, --model       Specify the model to use');
+      console.log('  -e, --e2bSandboxId       Specify the E2B sandbox ID to use. If not provided, the agent will run locally.');
       console.log('\n');
       continue;
     }
@@ -148,12 +150,14 @@ program
   .description('Start a conversation with the agent')
   .option('-d, --debug', 'Enable debug logging')
   .option('-m, --model <model>', 'Model to use', 'claude-3-7-sonnet-20250219')
+  .option('-e, --e2bSandboxId <e2bSandboxId>', 'E2B sandbox ID to use, if not provided, the agent will run locally')
   .action(startChat);
 
 // Default command (when no command is specified)
 program
   .option('-d, --debug', 'Enable debug logging')
   .option('-m, --model <model>', 'Model to use', 'claude-3-7-sonnet-20250219')
+  .option('-e, --e2bSandboxId <e2bSandboxId>', 'E2B sandbox ID to use, if not provided, the agent will run locally')
   .action(startChat);
 
 // Parse command line arguments

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -9,8 +9,14 @@ import { ToolRegistry } from './registry';
 import { Tool } from './tool';
 import { ModelProvider } from './model';
 
+// Define repository environment types
+export type RepositoryEnvironment = 
+  | { type: 'local' }
+  | { type: 'e2b', sandboxId: string };
+
 export interface AgentConfig {
   modelProvider: ModelProvider;
+  environment: RepositoryEnvironment;
   logger?: {
     debug: (message: string, ...args: unknown[]) => void;
     info: (message: string, ...args: unknown[]) => void;
@@ -24,7 +30,7 @@ export interface AgentConfig {
 
 export interface Agent {
   // Core components
-  agentRunner: AgentRunner;
+  agentRunner: (env: RepositoryEnvironment) => Promise<AgentRunner>;
   toolRegistry: ToolRegistry;
   permissionManager: PermissionManager;
   modelClient: ModelClient;

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -5,6 +5,7 @@
 import { GlobOptions } from "fs";
 import { FileEditToolResult } from "../tools/FileEditTool";
 import { FileReadToolResult } from "../tools/FileReadTool";
+import { LSToolResult } from "../tools/LSTool";
 
 export interface ExecutionAdapter {
   executeCommand: (command: string, workingDir?: string) => Promise<{
@@ -20,6 +21,8 @@ export interface ExecutionAdapter {
   readFile: (filepath: string, maxSize?: number, lineOffset?: number, lineCount?: number, encoding?: string) => Promise<FileReadToolResult>;
 
   writeFile: (filepath: string, content: string) => Promise<void>;
+
+  ls: (dirPath: string, showHidden?: boolean, details?: boolean) => Promise<LSToolResult>;
   
 }
 

--- a/src/utils/E2BExecutionAdapter.ts
+++ b/src/utils/E2BExecutionAdapter.ts
@@ -1,0 +1,247 @@
+import { Sandbox } from 'e2b';
+import { FileEditToolErrorResult, FileEditToolSuccessResult } from '../tools/FileEditTool';
+import { FileReadToolErrorResult, FileReadToolSuccessResult } from '../tools/FileReadTool';
+import { ExecutionAdapter } from '../types/tool';
+import { FileEntry, LSToolErrorResult, LSToolSuccessResult } from '../tools/LSTool';
+import path from 'path';
+
+export class E2BExecutionAdapter implements ExecutionAdapter {
+  private sandbox: Sandbox;
+
+  private constructor(sandbox: Sandbox) {
+    this.sandbox = sandbox;
+  }
+
+  /**
+   * Creates a new E2BExecutionAdapter instance with a connected sandbox
+   * @param sandboxId The ID of the sandbox to connect to
+   * @returns A fully initialized E2BExecutionAdapter
+   * @throws Error if connection to the sandbox fails
+   */
+  public static async create(sandboxId: string): Promise<E2BExecutionAdapter> {
+    try {
+      const sandbox = await Sandbox.connect(sandboxId);
+      return new E2BExecutionAdapter(sandbox);
+    } catch (error) {
+      console.error('Failed to connect to E2B sandbox:', error);
+      throw error;
+    }
+  }
+
+  async readFile(filepath: string, maxSize?: number, lineOffset?: number, lineCount?: number, encoding?: string) {
+    if (!encoding) {
+      encoding = 'utf8';
+    }
+    if (!maxSize) {
+      maxSize = 1048576;
+    }
+    if (!lineOffset) {
+      lineOffset = 0;
+    }
+    if (!lineCount) {
+      lineCount = undefined;
+    }
+    try {
+      const exists = await this.sandbox.files.exists(filepath);
+      if (!exists) {
+        return {
+          success: false as const,
+          path: filepath,
+          error: `File does not exist: ${filepath}`
+        } as FileReadToolErrorResult;
+      }
+      let fileContent = await this.sandbox.files.read(filepath);
+      // Handle line pagination if requested
+      if (lineOffset > 0 || lineCount !== undefined) {
+        const lines = fileContent.split('\n');
+        const startLine = Math.min(lineOffset, lines.length);
+        const endLine = lineCount !== undefined 
+          ? Math.min(startLine + lineCount, lines.length) 
+          : lines.length;
+        
+        fileContent = lines.slice(startLine, endLine).join('\n');
+        
+        return {
+          success: true as const,
+          path: filepath,
+          content: fileContent,
+          size: fileContent.length,
+          encoding,
+          pagination: {
+            totalLines: lines.length,
+            startLine,
+            endLine,
+            hasMore: endLine < lines.length
+          }
+        } as FileReadToolSuccessResult;
+      }
+      
+      return {
+        success: true as const,
+        path: filepath,
+        content: fileContent,
+        size: fileContent.length,
+        encoding
+      } as FileReadToolSuccessResult;
+    } catch (error: unknown) {
+      const err = error as Error;
+      throw new Error(`Failed to read file: ${err.message}`);
+    }
+  }
+
+  async writeFile(filepath: string, content: string) {
+    await this.sandbox.files.write(filepath, content);
+  }
+  
+  async executeCommand(command: string, workingDir?: string) {
+    return await this.sandbox.commands.run(command, { cwd: workingDir });
+  }
+  
+  async glob(pattern: string) {
+    try {
+      // First try using the glob command if it exists
+      const globCheck = await this.sandbox.commands.run('which glob || echo "not_found"');
+      
+      if (!globCheck.stdout.includes('not_found')) {
+        // If glob command exists, use it
+        const result = await this.sandbox.commands.run(`glob "${pattern}"`);
+        return result.stdout.trim().split('\n').filter(line => line.length > 0);
+      } else {
+        // Fall back to find command
+        const result = await this.sandbox.commands.run(`find . -type f -path "${pattern}" -not -path "*/node_modules/*" -not -path "*/\\.*"`);
+        return result.stdout.trim().split('\n').filter(line => line.length > 0);
+      }
+    } catch {
+      // If any error occurs, fall back to the most basic implementation
+      const result = await this.sandbox.commands.run(`ls -la ${pattern}`);
+      return result.stdout.trim().split('\n').filter(line => line.length > 0);
+    }
+  }
+  
+  async editFile(filepath: string, searchCode: string, replaceCode: string, encoding?: string) {
+    if (!encoding) {
+      encoding = 'utf8';
+    }
+    try {
+      const exists = await this.sandbox.files.exists(filepath);
+      if (!exists) {
+        return {
+          success: false as const,
+          path: filepath,
+          error: `File does not exist: ${filepath}`
+        } as FileEditToolErrorResult;
+      }
+      const fileContent = await this.sandbox.files.read(filepath);
+
+      // Count occurrences of the search code
+      // Using string split approach instead of regex for exact matching
+      const occurrences = fileContent.split(searchCode).length - 1;
+    
+      if (occurrences === 0) {
+        return {
+          success: false as const,
+          path: filepath,
+          error: `Search code not found in file: ${filepath}`
+        } as FileEditToolErrorResult;
+      }
+    
+      if (occurrences > 1) {
+        return {
+          success: false as const,
+          path: filepath,
+          error: `Found ${occurrences} instances of the search code. Please provide a more specific search code that matches exactly once.`
+        } as FileEditToolErrorResult;
+      }
+    
+      // Replace the code (only one match at this point)
+      const newContent = fileContent.replace(searchCode, replaceCode);
+    
+      await this.sandbox.files.write(filepath, newContent);
+      return {
+        success: true as const,
+        path: filepath,
+        originalContent: fileContent,
+        newContent: newContent
+      } as FileEditToolSuccessResult;
+    } catch (error: unknown) {
+      const err = error as Error;
+      return {
+        success: false as const,
+        path: filepath,
+        error: err.message
+      } as FileEditToolErrorResult;
+    }
+  }
+
+  async ls(dirPath: string, showHidden: boolean = false, details: boolean = false) {
+    try {
+      const exists = await this.sandbox.files.exists(dirPath);
+      if (!exists) {
+        return {
+          success: false as const,
+          path: dirPath,
+          error: `Directory does not exist: ${dirPath}`
+        } as LSToolErrorResult;
+      }
+      
+      // Read directory contents
+      console.log(`Listing directory: ${dirPath}`);
+      const entries = await this.sandbox.files.list(dirPath);
+
+      // Filter hidden files if needed
+      const filteredEntries = showHidden ? 
+        entries : 
+        entries.filter(entry => !entry.name.startsWith('.'));
+      
+      // Format the results
+      let results: FileEntry[];
+      
+      if (details) {
+        // Get detailed information for each entry
+        results = await Promise.all(
+          filteredEntries.map(async (entry) => {
+            const filePath = path.join(dirPath, entry.name);
+            const handle = await this.sandbox.commands.run(`stat -c "%F,%s,%Y,%Z" ${filePath}`, {
+              background: true
+            });
+            const result = await handle.wait();
+            const stats = result.stdout.trim().split('\n');
+            const [type, size, mtime, ctime] = stats;
+            return {
+              name: entry.name, 
+              type: type,
+              size: parseInt(size),
+              modified: new Date(mtime),
+              created: new Date(ctime),
+              isDirectory: type === 'directory',
+              isFile: type === 'file',
+              isSymbolicLink: type === 'symbolic_link'
+            };
+          })
+        );
+      } else {
+        results = filteredEntries.map(entry => ({
+          name: entry.name,
+          type: entry.type,
+          isDirectory: entry.type && entry.type === 'dir' || false,
+          isFile: entry.type && entry.type === 'file' || false,
+          isSymbolicLink: false // E2B doesn't give a way to check
+        }));
+      }
+
+      return {    
+        success: true as const,
+        path: dirPath,
+        entries: results,
+        count: results.length
+      } as LSToolSuccessResult;
+    } catch (error: unknown) {
+      const err = error as Error;
+      return {
+        success: false as const,
+        path: dirPath,
+        error: err.message
+      } as LSToolErrorResult;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new execution adapter for E2B cloud environments
- Allow running tools in remote sandbox instead of locally
- Add CLI option for specifying E2B sandbox ID

## Test plan
- Install dependencies with npm install
- Run CLI with --e2bSandboxId flag to test remote execution
- Verify all file operations and commands work in cloud environment

🤖 Generated with [Claude Code](https://claude.ai/code)