### PR TITLE
Fix postinstall script to handle missing dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "start:dist": "node dist/cli.js",
     "start:dev": "npm run build:complete && npm run start:dist -- --dev --port 3000",
     "prepublishOnly": "npm run build:complete",
-    "postinstall": "chmod +x ./dist/cli.js",
+    "postinstall": "[ -f ./dist/cli.js ] && chmod +x ./dist/cli.js || echo 'dist/cli.js not found, skipping chmod'",
     "prepack": "chmod +x ./dist/cli.js"
   },
   "keywords": [


### PR DESCRIPTION
This PR makes the postinstall script more resilient by checking if the dist/cli.js file exists before trying to chmod it. This prevents errors during npm install when the dist directory hasn't been created yet, which is common during development or when running in containers.

This fix should help with:
- Development workflows when running npm install before building
- Container environments where the build step might happen separately
- Our evaluation framework that's running in E2B sandbox

The change is simple but should make the package more robust for both users and developers.