### PR TITLE
Fix: Properly persist and restore agent conversation history

### DIFF
--- a/src/server/services/AgentService.ts
+++ b/src/server/services/AgentService.ts
@@ -38,6 +38,7 @@ import { previewService } from './preview/PreviewService';
 import { ServerError, AgentBusyError } from '../utils/errors';
 import { ExecutionAdapterFactoryOptions, createExecutionAdapter } from '../../utils/ExecutionAdapterFactory';
 import { serverLogger } from '../logger';
+import { LogCategory } from '../../types/logger';
 import { setSessionAborted, generateExecutionId } from '../../utils/sessionUtils';
 import { getSessionStatePersistence } from './sessionPersistenceProvider';
 import { ExecutionAdapter } from '../../types/tool';

--- a/src/server/services/AgentService.ts
+++ b/src/server/services/AgentService.ts
@@ -854,11 +854,17 @@ export class AgentService extends EventEmitter {
       await this.toolExecutionManager.saveSessionData(sessionId);
       await this.previewManager.saveSessionData(sessionId);
       
-      // Save message history
+      // Save UI message history
       await this.saveSessionMessages(sessionId);
       
       // Save repository information if available
       await this.saveRepositoryInfo(sessionId);
+      
+      // Get current session
+      const session = sessionManager.getSession(sessionId);
+      
+      // Save the complete session state with agent conversation history to persistence
+      await this.saveAgentSessionState(sessionId, session.state);
       
       // Save session metadata
       await this.saveSessionMetadata(sessionId);
@@ -872,6 +878,55 @@ export class AgentService extends EventEmitter {
       serverLogger.info(`Saved complete session state for session ${sessionId}`);
     } catch (error) {
       serverLogger.error(`Failed to save session state for session ${sessionId}:`, error);
+    }
+  }
+  
+  /**
+   * Save complete agent session state including conversation history
+   */
+  private async saveAgentSessionState(
+    sessionId: string, 
+    sessionState: { conversationHistory: Anthropic.Messages.MessageParam[] }
+  ): Promise<void> {
+    try {
+      // Get persistence service
+      const persistence = getSessionStatePersistence();
+      
+      // Get saved session data or create new if it doesn't exist
+      let sessionData = await persistence.getSessionDataWithoutEvents(sessionId);
+      if (!sessionData) {
+        // Create basic session data structure
+        const session = sessionManager.getSession(sessionId);
+        sessionData = {
+          id: sessionId,
+          name: `Session ${sessionId}`,
+          createdAt: session.createdAt.toISOString(),
+          updatedAt: new Date().toISOString(),
+          messages: [],
+          toolExecutions: [],
+          permissionRequests: [],
+          previews: [],
+          sessionState: { conversationHistory: [] }
+        };
+      }
+      
+      if (sessionData) {
+        // Update session state with conversation history included
+        sessionData.sessionState = sessionState;
+        sessionData.updatedAt = new Date().toISOString();
+        
+        // Save complete data
+        await persistence.saveSession(sessionData);
+        
+        // Log conversation history size
+        const historyLength = sessionState?.conversationHistory?.length || 0;
+        serverLogger.debug(
+          `Saved agent conversation history for session ${sessionId} (${historyLength} messages)`,
+          LogCategory.SESSION
+        );
+      }
+    } catch (error) {
+      serverLogger.error(`Failed to save agent session state for session ${sessionId}:`, error);
     }
   }
   

--- a/src/server/services/WebSocketService.ts
+++ b/src/server/services/WebSocketService.ts
@@ -247,6 +247,7 @@ export class WebSocketService {
               return;
             }
             
+            
             // Convert SavedSessionData to Session
             const session: Session = {
               id: sessionData.id,
@@ -256,6 +257,13 @@ export class WebSocketService {
               isProcessing: false,
               executionAdapterType: sessionData.sessionState?.executionAdapterType as 'local' | 'docker' | 'e2b' | undefined
             };
+            
+            // Log conversation history status
+            const historyLength = session.state.conversationHistory?.length || 0;
+            serverLogger.debug(
+              `Session ${sessionId} restored with ${historyLength} conversation history messages`,
+              LogCategory.SESSION
+            );
 
             // Add the session to the session manager
             this.sessionManager.addSession(session);

--- a/src/server/services/WebSocketService.ts
+++ b/src/server/services/WebSocketService.ts
@@ -3,6 +3,7 @@ import { Server as SocketIOServer, Socket } from 'socket.io';
 import { AgentService, AgentServiceEvent, getAgentService } from './AgentService';
 import { SessionManager, sessionManager, Session } from './SessionManager';
 import { serverLogger } from '../logger';
+import { LogCategory } from '../../types/logger';
 import { AgentEvents, AgentEventType, EnvironmentStatusEvent } from '../../utils/sessionUtils';
 import { 
   ToolPreviewData, 


### PR DESCRIPTION
## Summary
- Add dedicated method to save agent's conversation history in native Anthropic format
- Ensure agent state with conversation history is properly persisted and restored
- Add logging to track conversation history status during session reconnection

This fixes an issue where the agent would forget previous conversations when reconnecting to a session, even though the UI would show the conversation history. Now the agent will have full context of the previous conversation when a session is restored.

## Test plan
1. Start a conversation with the agent
2. Exit the session
3. Come back to the session
4. Verify that the agent remembers the previous conversation by asking about something discussed earlier

🤖 Generated with [Claude Code](https://claude.ai/code)