### PR TITLE
Fix: Remove sticky permission behavior for file edits

### DIFF
--- a/src/core/PermissionManager.ts
+++ b/src/core/PermissionManager.ts
@@ -19,8 +19,6 @@ export const createPermissionManager = (
 ): PermissionManager => {
   const logger = config.logger;
   
-  // Track granted permissions
-  const grantedPermissions = new Map<string, boolean>();
   
   // Fast Edit Mode state - when enabled, file operations don't require permission
   let fastEditMode = config.initialFastEditMode || false;
@@ -38,14 +36,6 @@ export const createPermissionManager = (
   };
   
   return {
-    /**
-     * Check if a tool has been granted permission
-     * @param toolId - The ID of the tool to check
-     * @returns Whether permission has been granted
-     */
-    hasPermission(toolId: string): boolean {
-      return grantedPermissions.has(toolId);
-    },
     
     /**
      * Request permission for a tool
@@ -112,7 +102,6 @@ export const createPermissionManager = (
       // Log the permission decision
       if (granted) {
         logger?.info(`Permission granted for tool: ${toolId}`, LogCategory.PERMISSIONS);
-        grantedPermissions.set(toolId, true);
       } else {
         logger?.info(`Permission denied for tool: ${toolId}`, LogCategory.PERMISSIONS);
       }
@@ -120,20 +109,6 @@ export const createPermissionManager = (
       return granted;
     },
     
-    /**
-     * Revoke permission for a tool
-     * @param toolId - The ID of the tool to revoke permission for
-     */
-    revokePermission(toolId: string): void {
-      grantedPermissions.delete(toolId);
-    },
-    
-    /**
-     * Clear all granted permissions
-     */
-    clearAllPermissions(): void {
-      grantedPermissions.clear();
-    },
     
     /**
      * Set the fast edit mode

--- a/src/tools/createTool.ts
+++ b/src/tools/createTool.ts
@@ -126,9 +126,9 @@ export const createTool = (config: ToolConfig): Tool => {
       }
       
       // Check permissions if needed
-      if (this.requiresPermission && 
-          context.permissionManager && 
-          !context.permissionManager.hasPermission(this.id)) {
+      if (this.requiresPermission && context.permissionManager) {
+        // Always call requestPermission which will handle all the checks internally
+        // This will ask for permission every time unless in fast edit mode
         const granted = await context.permissionManager.requestPermission(this.id, args);
         if (!granted) {
           throw new Error(`Permission denied for ${this.name}`);

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -21,10 +21,7 @@ export interface PermissionManagerConfig {
 }
 
 export interface PermissionManager {
-  hasPermission(toolId: string): boolean;
   requestPermission(toolId: string, args: Record<string, unknown>): Promise<boolean>;
-  revokePermission(toolId: string): void;
-  clearAllPermissions(): void;
   
   // Fast Edit Mode methods
   setFastEditMode(enabled: boolean): void;

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -8,6 +8,7 @@ import { FileReadToolResult } from "../tools/FileReadTool";
 import { LSToolResult } from "../tools/LSTool";
 import { GitRepositoryInfo } from "./session";
 import { SessionState } from "./model";
+import { PermissionManager } from "./permission";
 
 /**
  * Categories for tools to classify their purpose and permission requirements
@@ -90,10 +91,7 @@ export interface ToolConfig {
 }
 
 export interface ToolContext {
-  permissionManager?: {
-    hasPermission: (toolId: string) => boolean;
-    requestPermission: (toolId: string, args: Record<string, unknown>) => Promise<boolean>;
-  };
+  permissionManager?: PermissionManager;
   logger?: {
     debug: (message: string, ...args: unknown[]) => void;
     info: (message: string, ...args: unknown[]) => void;


### PR DESCRIPTION
## Summary
- Fixed a bug where file edit operations would only request permission once per session
- Removed the permission caching mechanism entirely from PermissionManager
- Each file edit operation will now request permission unless fast edit mode is enabled
- Simplified permission management by removing unnecessary methods and using consistent types

## Test plan
- Test file edit operations to ensure permission is requested for each edit
- Test fast edit mode to ensure permission is not requested when it's enabled
- Verify that the type system is happy with the changes (typecheck passes)

🤖 Generated with [Claude Code](https://claude.ai/code)