### PR TITLE
Fix permission system and add preview support for permission requests

### DIFF
--- a/src/core/PermissionManager.ts
+++ b/src/core/PermissionManager.ts
@@ -19,8 +19,6 @@ export const createPermissionManager = (
 ): PermissionManager => {
   const logger = config.logger;
   
-  // Track granted permissions
-  const grantedPermissions = new Map<string, boolean>();
   
   // Fast Edit Mode state - when enabled, file operations don't require permission
   let fastEditMode = config.initialFastEditMode || false;
@@ -38,14 +36,6 @@ export const createPermissionManager = (
   };
   
   return {
-    /**
-     * Check if a tool has been granted permission
-     * @param toolId - The ID of the tool to check
-     * @returns Whether permission has been granted
-     */
-    hasPermission(toolId: string): boolean {
-      return grantedPermissions.has(toolId);
-    },
     
     /**
      * Request permission for a tool
@@ -112,7 +102,6 @@ export const createPermissionManager = (
       // Log the permission decision
       if (granted) {
         logger?.info(`Permission granted for tool: ${toolId}`, LogCategory.PERMISSIONS);
-        grantedPermissions.set(toolId, true);
       } else {
         logger?.info(`Permission denied for tool: ${toolId}`, LogCategory.PERMISSIONS);
       }
@@ -120,20 +109,6 @@ export const createPermissionManager = (
       return granted;
     },
     
-    /**
-     * Revoke permission for a tool
-     * @param toolId - The ID of the tool to revoke permission for
-     */
-    revokePermission(toolId: string): void {
-      grantedPermissions.delete(toolId);
-    },
-    
-    /**
-     * Clear all granted permissions
-     */
-    clearAllPermissions(): void {
-      grantedPermissions.clear();
-    },
     
     /**
      * Set the fast edit mode

--- a/src/server/services/AgentService.ts
+++ b/src/server/services/AgentService.ts
@@ -222,8 +222,8 @@ export class AgentService extends EventEmitter {
     };
     
     // Initialize the new managers
-    this.toolExecutionManager = createToolExecutionManager() as ToolExecutionManagerImpl;
     this.previewManager = createPreviewManager() as PreviewManagerImpl;
+    this.toolExecutionManager = createToolExecutionManager(this.previewManager) as ToolExecutionManagerImpl;
     
     // Set up event forwarding from the tool execution manager
     this.setupToolExecutionEventForwarding();

--- a/src/server/services/AgentService.ts
+++ b/src/server/services/AgentService.ts
@@ -21,7 +21,9 @@ import {
   ToolExecutionState, 
   ToolExecutionStatus,
   ToolExecutionEvent,
-  PermissionRequestState
+  PermissionRequestState,
+  PermissionRequestedEventData,
+  PermissionResolvedEventData
 } from '../../types/tool-execution';
 
 import { ExecutionCompletedWithPreviewEventData } from './tool-execution/ToolExecutionManagerImpl';
@@ -272,26 +274,7 @@ export class AgentService extends EventEmitter {
             
           } else if (toolEvent === ToolExecutionEvent.PERMISSION_REQUESTED || 
                      toolEvent === ToolExecutionEvent.PERMISSION_RESOLVED) {
-            // For permission events, expect { execution, permission } structure
-            const typedData = data as { 
-              execution: ToolExecutionState; 
-              permission: PermissionRequestState;
-              sessionId?: string;
-            };
-            
-            const sessionId = typedData.sessionId || typedData.execution?.sessionId;
-            
-            // Create a new event data structure with the renamed field
-            const eventData = {
-              execution: typedData.execution,
-              permissionRequest: typedData.permission,
-              sessionId: sessionId
-            };
-            
-            if (toolEvent === ToolExecutionEvent.PERMISSION_REQUESTED) {
-                    }
-            
-            this.emit(agentEvent, eventData);
+            this.emit(agentEvent, data);
           }
           return; // Skip the standard emit flow
         }
@@ -336,9 +319,6 @@ export class AgentService extends EventEmitter {
         
       case ToolExecutionEvent.ABORTED:
         return this.transformToolAbortedEvent(data as ToolExecutionState);
-        
-      case ToolExecutionEvent.PERMISSION_REQUESTED:
-        return this.transformPermissionRequestedEvent(data as { execution: ToolExecutionState; permission: PermissionRequestState });
         
       case ToolExecutionEvent.PERMISSION_RESOLVED:
         return this.transformPermissionResolvedEvent(data as { execution: ToolExecutionState; permission: PermissionRequestState });
@@ -614,65 +594,6 @@ export class AgentService extends EventEmitter {
       timestamp: execution.endTime,
       startTime: execution.startTime,
       abortTimestamp: execution.endTime,
-      preview: preview ? this.convertPreviewStateToData(preview) : undefined
-    };
-  }
-  
-  /**
-   * Transform permission requested event data
-   */
-  private transformPermissionRequestedEvent(data: { execution: ToolExecutionState, permission: PermissionRequestState }): PermissionEventData {
-    const { execution, permission } = data;
-    
-    // Check if a preview exists already
-    let preview = this.previewManager.getPreviewForExecution(execution.id);
-    
-    // If no preview exists, generate a permission preview
-    if (!preview) {
-      try {
-        // Generate a preview specifically for this permission request
-        const permissionPreview = previewService.generatePermissionPreview(
-          { id: execution.toolId, name: execution.toolName },
-          permission.args || {}
-        );
-        
-        // Extract fullContent from permission preview if available
-        let fullContent: string | undefined = undefined;
-        
-        // Permission previews may have a fullContent field with details
-        if (permissionPreview.hasFullContent) {
-          // Try to safely extract fullContent from any preview with it
-          fullContent = (permissionPreview as unknown as { fullContent?: string }).fullContent;
-        }
-        
-        // Create and store the preview
-        preview = this.previewManager.createPreview(
-          execution.sessionId,
-          execution.id,
-          permissionPreview.contentType,
-          permissionPreview.briefContent,
-          fullContent,
-          { 
-            ...permissionPreview.metadata,
-            executionId: execution.id
-          }
-        );
-        
-        // Link the preview to the execution
-        this.toolExecutionManager.associatePreview(execution.id, preview.id);
-      } catch (error) {
-        serverLogger.error(`Error generating permission preview for ${execution.id}:`, error);
-      }
-    }
-    
-    return {
-      permissionId: permission.id,
-      sessionId: permission.sessionId,
-      toolId: permission.toolId,
-      toolName: permission.toolName,
-      executionId: execution.id,
-      args: permission.args,
-      timestamp: permission.requestTime,
       preview: preview ? this.convertPreviewStateToData(preview) : undefined
     };
   }
@@ -1338,9 +1259,6 @@ export class AgentService extends EventEmitter {
               return Promise.resolve(false);
             }
             
-            // Generate a preview for the permission request
-            this.generatePermissionPreview(executionId, toolId, args);
-            
             // Create a promise to wait for permission resolution
             return new Promise<boolean>(resolve => {
               // Store resolver in a closure that will be called when permission is resolved
@@ -1350,16 +1268,16 @@ export class AgentService extends EventEmitter {
               // Create a one-time event listener for permission resolution
               const onPermissionResolved = (data: unknown) => {
                 // Type check and cast the data
-                const typedData = data as { execution: ToolExecutionState; permission: PermissionRequestState };
+                const typedData = data as { execution: ToolExecutionState; permissionRequest: PermissionRequestState };
                 
                 // Check if this is our permission request
-                if (typedData.permission.id === permission.id) {
+                if (typedData.permissionRequest.id === permission.id) {
                   // Remove the listener to avoid memory leaks
                   const removeListener = this.toolExecutionManager.on(ToolExecutionEvent.PERMISSION_RESOLVED, onPermissionResolved);
                   removeListener();
                   
                   // Resolve with the permission status
-                  resolve(typedData.permission.granted || false);
+                  resolve(typedData.permissionRequest.granted || false);
                 }
               };
               
@@ -1486,9 +1404,10 @@ export class AgentService extends EventEmitter {
     try {
       // Directly use the ToolExecutionManager method to resolve permission
       const result = this.toolExecutionManager.resolvePermissionByExecutionId(executionId, granted);
+      console.log(`🔴🔴🔴 Permission resolved by execution ID: ${executionId}`, result);
       return !!result;
     } catch (error) {
-      serverLogger.error(`Error resolving permission for execution: ${executionId}`, error);
+      console.log(`Error resolving permission for execution: ${executionId}`, error);
       return false;
     }
   }
@@ -1569,83 +1488,6 @@ export class AgentService extends EventEmitter {
     }
   }
   
-  /**
-   * Generate a preview for a permission request
-   */
-  private generatePermissionPreview(
-    executionId: string,
-    toolId: string,
-    args: Record<string, unknown>
-  ): void {
-    try {
-      // Get the execution and permission from the manager
-      const execution = this.toolExecutionManager.getExecution(executionId);
-      if (!execution) {
-        serverLogger.warn(`No execution found for permission preview: ${executionId}`);
-        return;
-      }
-      
-      const permission = this.toolExecutionManager.getPermissionRequestForExecution(executionId);
-      if (!permission) {
-        serverLogger.warn(`No permission found for execution: ${executionId}`);
-        return;
-      }
-      
-      // Use the existing previewService to generate the preview
-      const toolInfo = {
-        id: toolId,
-        name: execution.toolName
-      };
-      
-      serverLogger.debug(`Generating permission preview for execution: ${executionId}`, {
-        toolId,
-        toolName: execution.toolName,
-        permissionId: permission.id
-      });
-      
-      // Generate the permission preview
-      const previewData = previewService.generatePermissionPreview(toolInfo, args);
-      if (!previewData) {
-        serverLogger.warn(`No preview data generated for permission request: ${permission.id}`);
-        return;
-      }
-      
-      serverLogger.debug(`Permission preview generated for execution ${executionId}:`, {
-        contentType: previewData.contentType,
-        hasBriefContent: !!previewData.briefContent,
-        hasFullContent: previewData.hasFullContent
-      });
-      
-      // Create a preview in the manager
-      // For TypeScript compatibility - check if there's full content available
-      const fullContent = previewData.hasFullContent 
-        ? (previewData as unknown as { fullContent: string }).fullContent
-        : undefined;
-        
-      const preview = this.previewManager.createPermissionPreview(
-        execution.sessionId,
-        executionId,
-        permission.id,
-        previewData.contentType,
-        previewData.briefContent,
-        fullContent,
-        previewData.metadata
-      );
-      
-      serverLogger.debug(`Permission preview created and stored for execution ${executionId}:`, {
-        previewId: preview.id,
-        executionId: preview.executionId,
-        permissionId: permission.id
-      });
-      
-      // Also update the execution to link to the preview
-      this.toolExecutionManager.updateExecution(executionId, { previewId: preview.id });
-      serverLogger.debug(`Updated execution ${executionId} with permission preview ID: ${preview.id}`);
-    } catch (error) {
-      serverLogger.error(`Error in generatePermissionPreview:`, error);
-    }
-  }
-
   /**
    * Get pending permission requests for a session
    */

--- a/src/server/services/WebSocketService.ts
+++ b/src/server/services/WebSocketService.ts
@@ -613,40 +613,29 @@ export class WebSocketService {
                 const preview = await this.getPreviewForExecution(executionId);
                 
                 if (preview) {
-                  // Convert to client format
-                  const formattedPreview = this.convertPreviewToClientFormat(preview);
+                  // Send enhanced update with the properly generated preview
+                  this.io.to(sessionId).emit(WebSocketEvent.TOOL_EXECUTION_UPDATED, {
+                    sessionId,
+                    toolExecution: {
+                      id: item.id,
+                      toolId: item.toolExecution.toolId,
+                      toolName: item.toolExecution.toolName,
+                      status: item.toolExecution.status,
+                      args: item.toolExecution.args,
+                      startTime: item.toolExecution.startTime,
+                      endTime: item.toolExecution.endTime,
+                      executionTime: item.toolExecution.executionTime,
+                      result: item.toolExecution.result,
+                      error: item.toolExecution.error,
+                      // Include the enhanced preview
+                      preview: preview,
+                      hasPreview: true,
+                      previewContentType: preview.contentType
+                    }
+                  });
                   
-                  if (formattedPreview) {
-                    serverLogger.info(`Enhanced timeline preview for ${executionId}:`, {
-                      contentType: preview.contentType,
-                      briefContentLength: preview.briefContent?.length,
-                      fullContentLength: preview.fullContent?.length
-                    });
-                    
-                    // Send enhanced update with the properly generated preview
-                    this.io.to(sessionId).emit(WebSocketEvent.TOOL_EXECUTION_UPDATED, {
-                      sessionId,
-                      toolExecution: {
-                        id: item.id,
-                        toolId: item.toolExecution.toolId,
-                        toolName: item.toolExecution.toolName,
-                        status: item.toolExecution.status,
-                        args: item.toolExecution.args,
-                        startTime: item.toolExecution.startTime,
-                        endTime: item.toolExecution.endTime,
-                        executionTime: item.toolExecution.executionTime,
-                        result: item.toolExecution.result,
-                        error: item.toolExecution.error,
-                        // Include the enhanced preview
-                        preview: formattedPreview,
-                        hasPreview: true,
-                        previewContentType: preview.contentType
-                      }
-                    });
-                    
-                    // We've sent the enhanced update, so return to avoid sending duplicate events
-                    return;
-                  }
+                  // We've sent the enhanced update, so return to avoid sending duplicate events
+                  return;
                 }
               }
             }
@@ -863,7 +852,7 @@ export class WebSocketService {
   private handlePermissionRequested(data: PermissionRequestedEventData & {
     sessionId: string;
   }): void {
-    const { sessionId, execution, permissionRequest, preview } = data;
+    const { execution, permissionRequest, preview } = data;
     
     if (!execution || !execution.id || !permissionRequest) {
       serverLogger.warn(`Invalid permission request data:`, data);
@@ -872,53 +861,8 @@ export class WebSocketService {
 
     const executionId = execution.id;
     
-    // Get the agent service for this session
-    const agentService = this.agentServiceRegistry.getServiceForSession(sessionId);
-    
-    // Get the full execution state
-    const fullExecution = agentService.getToolExecution(executionId);
-    
-    if (!fullExecution) {
-      serverLogger.warn(`Tool execution not found for permission request: ${executionId}`);
-      return;
-    }
-    
-    console.log(`🔴🔴🔴 Preview: ${preview}`);
-    if (!preview && permissionRequest.previewId) {
-      console.log(`🔴🔴🔴 Preview not found for permission request: ${permissionRequest.previewId}`);
-    }
-    
-    // Check if we have a preview in the event data or need to look it up
-    // let previewData = preview;
-    
-    // If no preview in event data but there's a previewId, try to get it
-    // if (!previewData && permissionRequest.previewId) {
-    //   previewData = agentService.getPreview(permissionRequest.previewId);
-    //   serverLogger.debug(`Retrieved preview for permission request from ID: ${permissionRequest.previewId}`, {
-    //     hasPreview: !!previewData,
-    //     contentType: previewData?.contentType
-    //   });
-    // }
-    
-    // If still no preview, try to get it from the execution
-    // if (!previewData) {
-    //   previewData = agentService.getPreviewForExecution(executionId);
-    //   if (previewData) {
-    //     serverLogger.debug(`Retrieved preview for permission request from execution: ${executionId}`, {
-    //       previewId: previewData.id,
-    //       contentType: previewData.contentType
-    //     });
-    //   }
-    // }
-    
-    // Format the preview for client if we have one
-    const formattedPreview = preview ? this.convertPreviewToClientFormat(preview) : null;
-    
-    // Send permission requested event - SIMPLIFIED FORMAT - with just executionId at top level
-    console.log(`🔴🔴🔴 Sending PERMISSION_REQUESTED for execution ${executionId} in session ${sessionId}`);
-    
-    this.io.to(sessionId).emit(WebSocketEvent.PERMISSION_REQUESTED, {
-      sessionId,
+    this.io.to(execution.sessionId).emit(WebSocketEvent.PERMISSION_REQUESTED, {
+      sessionId: execution.sessionId,
       executionId: executionId,
       permission: {
         id: permissionRequest.id,
@@ -928,13 +872,6 @@ export class WebSocketService {
         timestamp: permissionRequest.requestTime,
         executionId: executionId
       }
-    });
-    
-    // Also emit a tool execution update to ensure the status is properly set to "awaiting-permission"
-    // This ensures tools will appear in the activeTools array in useToolVisualization
-    serverLogger.info(`🔥 Sending TOOL_EXECUTION_UPDATED for execution ${executionId} with status "awaiting-permission"`, {
-      hasPreview: !!formattedPreview,
-      previewType: preview?.contentType
     });
     
     // Create the execution update with all necessary fields
@@ -949,21 +886,15 @@ export class WebSocketService {
     };
     
     // If we have a preview, include it in the update
-    if (formattedPreview) {
-      toolExecution.preview = formattedPreview;
+    if (preview) {
+      toolExecution.preview = preview;
       toolExecution.hasPreview = true;
       toolExecution.previewContentType = preview?.contentType;
-      
-      serverLogger.info(`Including preview in tool execution update for ${executionId}:`, {
-        previewId: preview?.id,
-        contentType: preview?.contentType,
-        formattedPreviewKeys: Object.keys(formattedPreview)
-      });
     }
     
     // Send the update
-    this.io.to(sessionId).emit(WebSocketEvent.TOOL_EXECUTION_UPDATED, {
-      sessionId,
+    this.io.to(execution.sessionId).emit(WebSocketEvent.TOOL_EXECUTION_UPDATED, {
+      sessionId: execution.sessionId,
       toolExecution
     });
   }
@@ -974,7 +905,7 @@ export class WebSocketService {
   private handlePermissionResolved(data: PermissionResolvedEventData & {
     sessionId: string;
   }): void {
-    const { sessionId, execution, permissionRequest } = data;
+    const { execution, permissionRequest, preview } = data;
     
     if (!execution || !execution.id || !permissionRequest) {
       serverLogger.warn(`Invalid permission resolution data:`, data);
@@ -984,23 +915,8 @@ export class WebSocketService {
     const executionId = execution.id;
     const granted = permissionRequest.granted;
     
-    // Get the agent service for this session
-    const agentService = this.agentServiceRegistry.getServiceForSession(sessionId);
-    
-    // Get the full execution state
-    const fullExecution = agentService.getToolExecution(executionId);
-    
-    if (!fullExecution) {
-      serverLogger.warn(`Tool execution not found for permission resolution: ${executionId}`);
-      return;
-    }
-    
-    // Emit consistent events using executionId
-    // Add enhanced logging to diagnose issues
-    console.log(`🔥 Sending PERMISSION_RESOLVED for execution ${executionId} in session ${sessionId}, granted: ${granted}`);
-    
-    this.io.to(sessionId).emit(WebSocketEvent.PERMISSION_RESOLVED, {
-      sessionId,
+    this.io.to(execution.sessionId).emit(WebSocketEvent.PERMISSION_RESOLVED, {
+      sessionId: execution.sessionId,
       executionId: executionId,
       resolution: granted
     });
@@ -1008,11 +924,10 @@ export class WebSocketService {
     // Also emit a tool execution update to ensure the status is updated based on the permission resolution
     // When permission is granted, the status returns to "running"; otherwise it should be "aborted"
     const newStatus = granted ? "running" : "aborted";
-    console.log(`🔥 Also sending TOOL_EXECUTION_UPDATED for execution ${executionId} with status "${newStatus}" after permission resolution`);
     
     // Also include the permissionRequest object in this update, ensuring all components receive the data in the same structure
-    this.io.to(sessionId).emit(WebSocketEvent.TOOL_EXECUTION_UPDATED, {
-      sessionId,
+    this.io.to(execution.sessionId).emit(WebSocketEvent.TOOL_EXECUTION_UPDATED, {
+      sessionId: execution.sessionId,
       toolExecution: {
         id: executionId,
         toolId: permissionRequest.toolId,
@@ -1025,214 +940,12 @@ export class WebSocketService {
           timestamp: permissionRequest.resolvedTime,
           executionId: executionId,
           granted: granted
-        }
+        },
+        preview: preview,
+        hasPreview: !!preview,
+        previewContentType: preview?.contentType
       }
     });
-  }
-  
-  /**
-   * Convert a tool execution state to the format expected by clients
-   * Now async to properly handle preview generation
-   */
-  private async convertExecutionToClientFormat(execution: ToolExecutionState): Promise<Record<string, unknown>> {
-    // Add extra logging for debugging
-    serverLogger.debug(`Converting execution to client format: ${execution.id}`, {
-      status: execution.status,
-      toolId: execution.toolId,
-      hasPreviewId: !!execution.previewId,
-      previewId: execution.previewId
-    });
-    
-    // Map ToolExecutionStatus to client status string
-    const statusMap: Record<ToolExecutionStatus, string> = {
-      [ToolExecutionStatus.PENDING]: 'pending',
-      [ToolExecutionStatus.RUNNING]: 'running',
-      [ToolExecutionStatus.AWAITING_PERMISSION]: 'awaiting-permission',
-      [ToolExecutionStatus.COMPLETED]: 'completed',
-      [ToolExecutionStatus.ERROR]: 'error',
-      [ToolExecutionStatus.ABORTED]: 'aborted'
-    };
-    
-    // Build the client data object
-    const clientData: Record<string, unknown> = {
-      id: execution.id,
-      tool: execution.toolId,
-      toolName: execution.toolName,
-      status: statusMap[execution.status],
-      args: execution.args,
-      startTime: new Date(execution.startTime).getTime(),
-      paramSummary: execution.summary
-    };
-    
-    // Add optional fields if present
-    if (execution.result !== undefined) {
-      clientData.result = execution.result;
-    }
-    
-    if (execution.error) {
-      clientData.error = execution.error;
-    }
-    
-    if (execution.endTime) {
-      clientData.endTime = new Date(execution.endTime).getTime();
-    }
-    
-    if (execution.executionTime) {
-      clientData.executionTime = execution.executionTime;
-    }
-    
-    if (execution.permissionId) {
-      clientData.permissionId = execution.permissionId;
-    }
-    
-    // Add preview if available - now with proper async handling
-    // First, try to use the preview ID if it exists
-    if (execution.previewId) {
-      try {
-        serverLogger.debug(`Execution ${execution.id} has previewId: ${execution.previewId}`);
-        // Properly await the preview retrieval
-        const preview = await this.getPreviewForExecution(execution.id);
-        if (preview) {
-          serverLogger.info(`Preview found for execution ${execution.id}:`, {
-            previewId: preview.id,
-            contentType: preview.contentType,
-            briefContentLength: preview.briefContent?.length,
-            fullContentLength: preview.fullContent?.length
-          });
-          
-          // Convert preview to client format with validation
-          const formattedPreview = this.convertPreviewToClientFormat(preview);
-          
-          // Only set preview data if we have valid preview content
-          if (formattedPreview) {
-            clientData.preview = formattedPreview;
-            
-            // These are important for the client to know there's a preview available
-            clientData.hasPreview = true;
-            clientData.previewContentType = preview.contentType;
-            clientData.previewBriefContentLength = preview.briefContent?.length;
-            clientData.previewFullContentLength = preview.fullContent?.length;
-            clientData.previewMetadataKeys = preview.metadata ? Object.keys(preview.metadata) : [];
-            
-            // Log detailed preview content to help diagnose potential issues
-            serverLogger.info(`Adding preview to client data for ${execution.id}:`, {
-              hasPreview: true,
-              contentType: preview.contentType,
-              briefContent: preview.briefContent?.substring(0, 50) + (preview.briefContent?.length > 50 ? '...' : ''),
-              briefContentLength: preview.briefContent?.length,
-              fullContentLength: preview.fullContent?.length,
-              metadataKeys: preview.metadata ? Object.keys(preview.metadata) : []
-            });
-          } else {
-            serverLogger.warn(`Invalid preview data for execution ${execution.id}: missing required fields`);
-            clientData.hasPreview = false;
-          }
-        } else {
-          serverLogger.warn(`No preview found for execution ${execution.id} despite having previewId: ${execution.previewId}`);
-          clientData.hasPreview = false;
-        }
-      } catch (error) {
-        serverLogger.error(`Error getting preview for execution ${execution.id}:`, error);
-        clientData.hasPreview = false;
-      }
-    } else {
-      // Try to get preview even if there's no previewId - sometimes it might exist
-      try {
-        serverLogger.debug(`Execution ${execution.id} has no previewId, trying to find preview anyway`);
-        // Properly await the preview generation
-        const preview = await this.getPreviewForExecution(execution.id);
-        if (preview) {
-          serverLogger.info(`Preview generated for execution ${execution.id} despite no previewId:`, {
-            previewId: preview.id,
-            contentType: preview.contentType,
-            briefContentLength: preview.briefContent?.length,
-            fullContentLength: preview.fullContent?.length
-          });
-          
-          // Convert preview to client format with validation
-          const formattedPreview = this.convertPreviewToClientFormat(preview);
-          
-          // Only set preview data if we have valid preview content
-          if (formattedPreview) {
-            clientData.preview = formattedPreview;
-            
-            // These are important for the client to know there's a preview available
-            clientData.hasPreview = true;
-            clientData.previewContentType = preview.contentType;
-            clientData.previewBriefContentLength = preview.briefContent?.length;
-            clientData.previewFullContentLength = preview.fullContent?.length;
-            clientData.previewMetadataKeys = preview.metadata ? Object.keys(preview.metadata) : [];
-            
-            // Log detailed preview content to help diagnose potential issues
-            serverLogger.info(`Adding generated preview to client data for ${execution.id}:`, {
-              hasPreview: true,
-              contentType: preview.contentType,
-              briefContent: preview.briefContent?.substring(0, 50) + (preview.briefContent?.length > 50 ? '...' : ''),
-              briefContentLength: preview.briefContent?.length,
-              fullContentLength: preview.fullContent?.length,
-              metadataKeys: preview.metadata ? Object.keys(preview.metadata) : []
-            });
-          } else {
-            serverLogger.warn(`Invalid generated preview data for execution ${execution.id}: missing required fields`);
-            clientData.hasPreview = false;
-          }
-        } else {
-          clientData.hasPreview = false;
-        }
-      } catch (error) {
-        // Log more details about the error
-        serverLogger.warn(`Error generating preview for execution ${execution.id} without previewId:`, error);
-        clientData.hasPreview = false;
-      }
-    }
-    
-    return clientData;
-  }
-  
-  /**
-   * Convert a preview state to the format expected by clients
-   */
-  private convertPreviewToClientFormat(preview: ToolPreviewState): Record<string, unknown> | null {
-    // Validate that the preview has required fields
-    if (!preview.contentType) {
-      serverLogger.warn(`Invalid preview data for ${preview.id}: missing contentType`);
-      return null;
-    }
-    
-    // Ensure briefContent is not empty or undefined
-    if (!preview.briefContent || preview.briefContent.trim() === '') {
-      serverLogger.warn(`Preview ${preview.id} has empty briefContent - adding placeholder`);
-      
-      // Set a placeholder message based on content type
-      let placeholderContent = '[Preview content unavailable]';
-      
-      if (preview.contentType === 'directory') {
-        placeholderContent = `Directory listing preview:\n\nFiles and directories will be shown here`;
-      } else if (preview.contentType === 'code') {
-        placeholderContent = `Code preview:\n\nFile contents will be shown here`;
-      } else if (preview.contentType === 'diff') {
-        placeholderContent = `Diff preview:\n\nChanges will be shown here`;
-      }
-      
-      // Log that we're adding placeholder content
-      serverLogger.info(`Adding placeholder content for preview ${preview.id} of type ${preview.contentType}`);
-      
-      // Return preview with placeholder content
-      return {
-        contentType: preview.contentType,
-        briefContent: placeholderContent,
-        fullContent: preview.fullContent || placeholderContent,
-        metadata: preview.metadata
-      };
-    }
-    
-    // Normal case - return the preview with its content
-    return {
-      contentType: preview.contentType,
-      briefContent: preview.briefContent,
-      fullContent: preview.fullContent,
-      metadata: preview.metadata
-    };
   }
   
   /**

--- a/src/server/services/tool-execution/ToolExecutionManagerImpl.ts
+++ b/src/server/services/tool-execution/ToolExecutionManagerImpl.ts
@@ -5,7 +5,9 @@ import {
   ToolExecutionState,
   ToolExecutionStatus,
   ToolExecutionEvent,
-  PermissionRequestState
+  PermissionRequestState,
+  PermissionRequestedEventData,
+  PermissionResolvedEventData
 } from '../../../types/tool-execution';
 import { SessionStatePersistence } from '../SessionStatePersistence';
 import { getSessionStatePersistence } from '../sessionPersistenceProvider';
@@ -20,7 +22,7 @@ export interface ExecutionCompletedWithPreviewEventData {
   execution: ToolExecutionState;
   preview?: ToolPreviewState;
 }
-import { PreviewManager, ToolPreviewState } from '../../../types/preview';
+import { PreviewManager, ToolPreviewData, ToolPreviewState } from '../../../types/preview';
 import { createPreviewManager } from '../PreviewManagerImpl';
 import { previewService } from '../preview';
 import { serverLogger } from '../../logger';
@@ -172,14 +174,22 @@ export class ToolExecutionManagerImpl implements ToolExecutionManager {
       const previewMgr = previewManager || createPreviewManager();
       
       // Check if we already have a preview
+      // If the execution status is COMPLETED, always generate a fresh completion preview
+      // This ensures we replace any permission preview with an actual result preview
       if (execution.previewId) {
         const existingPreview = previewMgr.getPreview(execution.previewId);
+        
+        // Log information about existing preview for debugging
         if (existingPreview) {
-          serverLogger.debug(`Preview already exists for execution ${executionId}`, {
+          serverLogger.debug(`Found existing preview for execution ${executionId}`, {
             previewId: existingPreview.id,
-            contentType: existingPreview.contentType
+            contentType: existingPreview.contentType,
+            isPermissionPreview: existingPreview.metadata?.isPermissionPreview || false
           });
-          return existingPreview;
+          
+          // If this is a completed execution, we always want to generate a new preview
+          // to replace any permission preview with the actual result preview
+          serverLogger.debug(`For completed execution ${executionId}, generating fresh result preview`);
         }
       }
       
@@ -200,16 +210,30 @@ export class ToolExecutionManagerImpl implements ToolExecutionManager {
         return null;
       }
       
+      // Enhance metadata to mark as completion preview
+      const enhancedMetadata = {
+        ...generatedPreview.metadata,
+        isCompletionPreview: true,
+        completionTime: new Date().toISOString()
+      };
+      
+      // Extract fullContent if available
+      let fullContent = undefined;
+      if (generatedPreview.hasFullContent && 'fullContent' in generatedPreview) {
+        fullContent = (generatedPreview as any).fullContent;
+      } else if (generatedPreview.briefContent) {
+        // Use briefContent as fallback
+        fullContent = generatedPreview.briefContent;
+      }
+      
       // Create a preview state
       const preview = previewMgr.createPreview(
         execution.sessionId,
         execution.id,
         generatedPreview.contentType,
         generatedPreview.briefContent,
-        generatedPreview.hasFullContent ? 
-          // If fullContent is available, extract it from the generated preview
-          (generatedPreview as any).fullContent : undefined,
-        generatedPreview.metadata
+        fullContent,
+        enhancedMetadata
       );
       
       // Associate the preview with the execution
@@ -365,6 +389,16 @@ export class ToolExecutionManagerImpl implements ToolExecutionManager {
       throw new Error(`Tool execution not found: ${executionId}`);
     }
 
+    // Check if there's already a permission request for this execution
+    const existingPermissionId = this.executionPermissions.get(executionId);
+    if (existingPermissionId) {
+      const existingPermission = this.permissionRequests.get(existingPermissionId);
+      if (existingPermission && !existingPermission.resolvedTime) {
+        serverLogger.warn(`Permission request already exists for execution ${executionId}, returning existing request`);
+        return existingPermission;
+      }
+    }
+
     const id = uuidv4();
     const permissionRequest: PermissionRequestState = {
       id,
@@ -391,18 +425,111 @@ export class ToolExecutionManagerImpl implements ToolExecutionManager {
     // Update execution status
     this.updateStatus(executionId, ToolExecutionStatus.AWAITING_PERMISSION);
 
-    // Emit event
-    this.emitEvent(ToolExecutionEvent.PERMISSION_REQUESTED, {
-      execution: this.executions.get(executionId),
-      permission: permissionRequest
-    });
+    // Check if we already have a preview for this execution
+    let previewId = execution.previewId;
+    let previewState;
+
+    // If no existing preview, generate one for the permission
+    if (!previewId) {
+      try {
+        const toolInfo = {
+          id: execution.toolId,
+          name: execution.toolName
+        };
+        
+        console.log(`Generating permission preview for ${executionId} (${toolInfo.name})`, {
+          toolId: toolInfo.id,
+          toolName: toolInfo.name,
+          executionId,
+          argsKeys: Object.keys(args)
+        });
+        
+        // Generate a permission preview using the preview service
+        const preview: ToolPreviewData  = previewService.generatePermissionPreview(toolInfo, args);
+        
+        // If we have a preview, associate it with the execution
+        if (preview) {
+          // Use or create a preview manager
+          const previewMgr = createPreviewManager();
+          
+          // Make sure metadata includes isPermissionPreview flag
+          const enhancedMetadata = {
+            ...preview.metadata,
+            isPermissionPreview: true,
+            permissionRequestTime: new Date().toISOString()
+          };
+          
+          // Create a preview state
+          // For permission previews, check if we need to extract any fullContent
+          let fullContent: string | undefined = undefined;
+          if (preview.hasFullContent && 'fullContent' in preview) {
+            fullContent = preview.fullContent as string;
+          } else {
+            // Use briefContent as fallback
+            fullContent = preview.briefContent;
+          }
+          
+          previewState = previewMgr.createPreview(
+            execution.sessionId,
+            execution.id,
+            preview.contentType,
+            preview.briefContent,
+            fullContent,
+            enhancedMetadata
+          );
+          
+          // Get the preview ID
+          previewId = previewState.id;
+          
+          // Associate the preview with the execution
+          this.associatePreview(execution.id, previewId);
+          
+          console.log(`Generated permission preview for execution ${executionId}`, {
+            previewId: previewId,
+            contentType: preview.contentType,
+            briefContentLength: preview.briefContent?.length || 0,
+            hasFullContent: preview.hasFullContent || false
+          });
+        }
+      } catch (error) {
+        console.error(`Error generating permission preview for ${executionId}:`, error);
+      }
+    } else {
+      // Use existing preview
+      console.log(`Using existing preview ${previewId} for permission request ${id}`);
+      
+      // Get the preview manager
+      const previewMgr = createPreviewManager();
+      
+      // Get the existing preview
+      previewState = previewMgr.getPreview(previewId);
+    }
+
+    // Update permission request with preview ID for consistent handling
+    if (previewId) {
+      permissionRequest.previewId = previewId;
+      // Update the stored permission request with the preview ID
+      this.permissionRequests.set(id, permissionRequest);
+    }
     
-    serverLogger.debug(`Created permission request: ${id} for execution: ${executionId}`, {
+    // Emit the event with the execution and permission request
+    // Include preview if available
+    const eventData: PermissionRequestedEventData = {
+      execution: this.executions.get(executionId)!,
+      permissionRequest,
+      preview: previewState
+    };
+   
+    console.log(`🔴🔴🔴 Permission requested event data: ${JSON.stringify(eventData)}`);
+    this.emitEvent(ToolExecutionEvent.PERMISSION_REQUESTED, eventData);
+    
+    serverLogger.debug(`Created permission request: ${id} for execution: ${executionId}${previewId ? ' with preview' : ''}`, {
       permissionId: id,
       executionId,
-      toolId: execution.toolId
+      toolId: execution.toolId,
+      previewId
     });
-
+    
     return permissionRequest;
   }
 
@@ -440,8 +567,8 @@ export class ToolExecutionManagerImpl implements ToolExecutionManager {
     // Emit event
     this.emitEvent(ToolExecutionEvent.PERMISSION_RESOLVED, {
       execution,
-      permission: updatedPermission
-    });
+      permissionRequest: updatedPermission
+    } as PermissionResolvedEventData);
     
     serverLogger.debug(`Resolved permission request: ${permissionId}`, {
       permissionId,
@@ -521,8 +648,8 @@ export class ToolExecutionManagerImpl implements ToolExecutionManager {
     
     // For permission events, ensure permissionRequest is defined and has an id
     if (event === ToolExecutionEvent.PERMISSION_REQUESTED || event === ToolExecutionEvent.PERMISSION_RESOLVED) {
-      const typedData = data as { permission?: PermissionRequestState; execution?: ToolExecutionState };
-      if (!typedData.permission || !typedData.permission.id || !typedData.execution) {
+      const typedData = data as { permissionRequest?: PermissionRequestState; execution?: ToolExecutionState };
+      if (!typedData.permissionRequest || !typedData.permissionRequest.id || !typedData.execution) {
         serverLogger.error(`Cannot emit ${event} with invalid permission data:`, typedData);
         return;
       }

--- a/src/tools/createTool.ts
+++ b/src/tools/createTool.ts
@@ -126,9 +126,9 @@ export const createTool = (config: ToolConfig): Tool => {
       }
       
       // Check permissions if needed
-      if (this.requiresPermission && 
-          context.permissionManager && 
-          !context.permissionManager.hasPermission(this.id)) {
+      if (this.requiresPermission && context.permissionManager) {
+        // Always call requestPermission which will handle all the checks internally
+        // This will ask for permission every time unless in fast edit mode
         const granted = await context.permissionManager.requestPermission(this.id, args);
         if (!granted) {
           throw new Error(`Permission denied for ${this.name}`);

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -21,10 +21,7 @@ export interface PermissionManagerConfig {
 }
 
 export interface PermissionManager {
-  hasPermission(toolId: string): boolean;
   requestPermission(toolId: string, args: Record<string, unknown>): Promise<boolean>;
-  revokePermission(toolId: string): void;
-  clearAllPermissions(): void;
   
   // Fast Edit Mode methods
   setFastEditMode(enabled: boolean): void;

--- a/src/types/tool-execution/index.ts
+++ b/src/types/tool-execution/index.ts
@@ -213,6 +213,7 @@ export interface PermissionRequestedEventData {
 export interface PermissionResolvedEventData {
   execution: ToolExecutionState;
   permissionRequest: PermissionRequestState;
+  preview?: ToolPreviewState;
 }
 
 /**

--- a/src/types/tool-execution/index.ts
+++ b/src/types/tool-execution/index.ts
@@ -199,6 +199,23 @@ export interface ExecutionCompletedWithPreviewEventData {
 }
 
 /**
+ * Type for data emitted with the PERMISSION_REQUESTED event
+ */
+export interface PermissionRequestedEventData {
+  execution: ToolExecutionState;
+  permissionRequest: PermissionRequestState;
+  preview?: ToolPreviewState;
+}
+
+/**
+ * Type for data emitted with the PERMISSION_RESOLVED event
+ */
+export interface PermissionResolvedEventData {
+  execution: ToolExecutionState;
+  permissionRequest: PermissionRequestState;
+}
+
+/**
  * Interface for tool execution manager
  */
 export interface ToolExecutionManager {

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -8,6 +8,7 @@ import { FileReadToolResult } from "../tools/FileReadTool";
 import { LSToolResult } from "../tools/LSTool";
 import { GitRepositoryInfo } from "./session";
 import { SessionState } from "./model";
+import { PermissionManager } from "./permission";
 
 /**
  * Categories for tools to classify their purpose and permission requirements
@@ -90,10 +91,7 @@ export interface ToolConfig {
 }
 
 export interface ToolContext {
-  permissionManager?: {
-    hasPermission: (toolId: string) => boolean;
-    requestPermission: (toolId: string, args: Record<string, unknown>) => Promise<boolean>;
-  };
+  permissionManager?: PermissionManager;
   logger?: {
     debug: (message: string, ...args: unknown[]) => void;
     info: (message: string, ...args: unknown[]) => void;

--- a/src/ui/context/TerminalContext.tsx
+++ b/src/ui/context/TerminalContext.tsx
@@ -287,52 +287,6 @@ export const TerminalProvider: React.FC<{ children: ReactNode }> = ({ children }
       dispatch({ type: 'CLEAR_STREAM_BUFFER' });
     };
     
-    // Handler for tool execution event - now handled by tool visualization
-    const handleToolExecution = ({ 
-      _sessionId, 
-      _tool, 
-      _result 
-    }: { 
-      _sessionId: string, 
-      _tool: { 
-        id: string; 
-        name: string;
-      }, 
-      _result: unknown 
-    }) => {
-      // Tool execution is now handled by the ToolVisualization component
-      // No need to track current tool in TerminalContext anymore
-    };
-    
-    
-    // Handler for permission requested event
-    const handlePermissionRequested = ({ 
-      _sessionId, 
-      permission 
-    }: { 
-      _sessionId: string, 
-      permission: { 
-        toolId: string;
-        id: string;
-        args: Record<string, unknown>;
-        timestamp: string;
-      }
-    }) => {
-      // We no longer add a system message for permission requests
-      // The UI will show permission requests in the tool visualization
-      console.log('Permission request received in TerminalContext, handled by ToolVisualization:', permission);
-    };
-    
-    // Handler for permission resolved event
-    const handlePermissionResolved = ({ 
-      _sessionId, 
-      permissionId, 
-      resolution 
-    }: { _sessionId: string, permissionId: string, resolution: boolean }) => {
-      // Just log to console, don't add a system message
-      console.log(`Permission ${resolution ? 'granted' : 'denied'} for request ${permissionId}`);
-    };
-    
     // Handler for session updated event - displays messages from the conversation history
     const handleSessionUpdated = (sessionData: SessionData) => {
       console.log('SESSION_UPDATED event received:', JSON.stringify(sessionData, null, 2));
@@ -454,39 +408,12 @@ export const TerminalProvider: React.FC<{ children: ReactNode }> = ({ children }
     const processAbortedWrapper = (data: { sessionId: string }) => 
       handleProcessingAborted({ _sessionId: data.sessionId });
     
-    const toolExecutionWrapper = (data: { sessionId: string, tool: { id: string; name: string }, result: unknown }) => 
-      handleToolExecution({ 
-        _sessionId: data.sessionId, 
-        _tool: data.tool, 
-        _result: data.result 
-      });
-    
-    const permissionRequestedWrapper = (data: { sessionId: string, permission: { id: string; toolId: string; args: Record<string, unknown>; timestamp: string; } }) => 
-      handlePermissionRequested({ 
-        _sessionId: data.sessionId, 
-        permission: { 
-          toolId: data.permission.toolId, 
-          id: data.permission.id,
-          args: data.permission.args,
-          timestamp: data.permission.timestamp
-        } 
-      });
-    
-    const permissionResolvedWrapper = (data: { sessionId: string, executionId: string, resolution: boolean }) => 
-      handlePermissionResolved({ 
-        _sessionId: data.sessionId, 
-        permissionId: data.executionId, // Map executionId to permissionId for compatibility
-        resolution: data.resolution 
-      });
     
     const cleanupFunctions = [
       websocketContext.on(WebSocketEvent.PROCESSING_STARTED, processStartedWrapper),
       websocketContext.on(WebSocketEvent.PROCESSING_COMPLETED, processCompletedWrapper),
       websocketContext.on(WebSocketEvent.PROCESSING_ERROR, processErrorWrapper),
       websocketContext.on(WebSocketEvent.PROCESSING_ABORTED, processAbortedWrapper),
-      websocketContext.on(WebSocketEvent.TOOL_EXECUTION, toolExecutionWrapper),
-      websocketContext.on(WebSocketEvent.PERMISSION_REQUESTED, permissionRequestedWrapper),
-      websocketContext.on(WebSocketEvent.PERMISSION_RESOLVED, permissionResolvedWrapper),
       websocketContext.on(WebSocketEvent.SESSION_UPDATED, handleSessionUpdated)
     ];
     


### PR DESCRIPTION
## Summary
- Fixes the permission system to correctly handle one-time permissions instead of sticky permissions
- Adds support for previews on tool visualizations with permission requests
- Fixes a critical bug causing TypeError on permission resolution

## Test plan
- Verify permission dialogs show proper preview content
- Verify permission behavior is per-execution instead of sticky per-tool-type
- Check permission resolution through the UI works correctly
- Ensure tool visualization properly displays previews for tools awaiting permission

🤖 Generated with [Claude Code](https://claude.ai/code)