### PR TITLE
Refactor tool execution with withToolCall utility

### DIFF
--- a/src/utils/withToolCall.ts
+++ b/src/utils/withToolCall.ts
@@ -1,0 +1,57 @@
+import { ToolCall, SessionState } from '../types/model';
+import { ToolResultEntry } from '../types/agent';
+import { ToolContext } from '../types/tool';
+
+/**
+ * Executes a tool call and guarantees that a matching `tool_result` block is
+ * added to the conversation history – even on error or abort.
+ *
+ * It also appends an entry to the in‑memory `toolResults` array that the
+ * AgentRunner uses for its cumulative result.
+ */
+export async function withToolCall(
+  toolCall: ToolCall,
+  sessionState: SessionState,
+  toolResults: ToolResultEntry[],
+  exec: (ctx: ToolContext) => Promise<unknown>,
+  context: ToolContext,
+): Promise<unknown> {
+  let result: unknown;
+  let aborted = false;
+
+  try {
+    result = await exec(context);
+  } catch (err) {
+    if ((err as Error).message === 'AbortError') {
+      aborted = true;
+    }
+    result = { error: String(err) };
+  }
+
+  // Always append tool_result to conversation history.
+  if (sessionState.contextWindow && toolCall.toolUseId) {
+    sessionState.contextWindow.push({
+      role: 'user',
+      content: [
+        {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          type: 'tool_result' as const,
+          tool_use_id: toolCall.toolUseId,
+          content: JSON.stringify(result),
+        },
+      ],
+    });
+  }
+
+  toolResults.push({
+    toolId: toolCall.toolId,
+    args: toolCall.args as Record<string, unknown>,
+    result,
+    toolUseId: toolCall.toolUseId,
+    aborted,
+  });
+
+  if (aborted) throw new Error('AbortError');
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Extracts tool execution lifecycle management into a dedicated `withToolCall` utility function
- Guarantees tool results are consistently added to both conversation history and results array
- Properly handles errors and aborts during tool execution
- Simplifies AgentRunner code by removing duplicate logic

## Test plan
- Run server tests to verify tool execution still works properly
- Test abort behavior to ensure it's properly propagated
- Verify tool results with errors show correctly in the UI

🤖 Generated with [Claude Code](https://claude.ai/code)