### PR TITLE
PR 5: Migrate to ContextWindow typed helpers

### DIFF
--- a/src/core/ModelClient.ts
+++ b/src/core/ModelClient.ts
@@ -183,19 +183,11 @@ export const createModelClient = (config: ModelClientConfig): ModelClient => {
         
         // Add the assistant's tool use response to the conversation history only if not aborted
         if (sessionState.contextWindow && toolUse && !isSessionAborted(getSessionId(sessionState))) {
-          const toolUseMessage: Anthropic.Messages.MessageParam = {
-            role: "assistant",
-            content: [
-              {
-                type: "tool_use" as const,
-                id: toolUse.id,
-                name: toolUse.name,
-                input: toolUse.input || {}
-              }
-            ]
-          };
-          
-          sessionState.contextWindow.push(toolUseMessage);
+          sessionState.contextWindow.pushToolUse({
+            id: toolUse.id,
+            name: toolUse.name,
+            input: (toolUse.input || {}) as Record<string, unknown>,
+          });
           console.log('⚠️ MODEL_CLIENT added tool use to context window:', {
             toolName: toolUse.name,
             historyLength: sessionState.contextWindow.getLength()

--- a/src/utils/withToolCall.ts
+++ b/src/utils/withToolCall.ts
@@ -30,17 +30,7 @@ export async function withToolCall(
 
   // Always append tool_result to conversation history.
   if (sessionState.contextWindow && toolCall.toolUseId) {
-    sessionState.contextWindow.push({
-      role: 'user',
-      content: [
-        {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          type: 'tool_result' as const,
-          tool_use_id: toolCall.toolUseId,
-          content: JSON.stringify(result),
-        },
-      ],
-    });
+    sessionState.contextWindow.pushToolResult(toolCall.toolUseId, result);
   }
 
   toolResults.push({


### PR DESCRIPTION
## Summary
- Added typed helpers (pushUser/pushAssistant/pushToolUse/pushToolResult) to ContextWindow to enforce consistency
- Added validation that runs in dev mode to enforce tool_use→tool_result rule
- Replaced all raw contextWindow.push(...) calls with typed helpers for better safety and readability
- Type checks pass and existing test suite (including abortSignal test) still passes

## Test plan
- Verify all type checks pass (`npm run typecheck`)
- Run existing test suite to ensure functionality is maintained

🤖 Generated with [Claude Code](https://claude.ai/code)